### PR TITLE
Information about getting InstanceId automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Use the official Docker image:
 docker run -d -e AWS_INSTANCE_ID="" -e AWS_ACCESS_KEY_ID="" -e AWS_SECRET_ACCESS_KEY="" --name collector mlabouardy/mon-put-instance-data --memory --swap --interval 1
 ```
 
+If you omit the `AWS_INSTANCE_ID` it'll get the instance id from `http://169.254.169.254/latest/meta-data/instance-id`
+
 ## Metrics
 
 * Memory


### PR DESCRIPTION
### Description
I saw that it's able to get the instanceID automatically but this is not in the docs.

### Related Issue

### Changes proposed 
Changed the README shwoing that the instanceID could be got automatically if the `AWS_INSTANCE_ID` not is present.

### Screenshots
